### PR TITLE
Removed .env dependency, use keystore for secure deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out/
 # Ignores development broadcast logs
 !/broadcast
 /broadcast/*/31337/
+/broadcast/*/11155111/
 /broadcast/**/dry-run/
 
 # Docs

--- a/script/DeployDSCEngine.s.sol
+++ b/script/DeployDSCEngine.s.sol
@@ -12,18 +12,13 @@ contract DeployDSCEngine is Script {
 
     function run() external returns (DecentralizedStableCoin, DSCEngine, HelperConfig) {
         HelperConfig config = new HelperConfig();
-        (
-            address ethUsdPriceFeed,
-            address btcUsdPriceFeed,
-            address wethAddress,
-            address wbtcAddress,
-            uint256 deployerKey
-        ) = config.activeNetworkConfig();
+        (address ethUsdPriceFeed, address btcUsdPriceFeed, address wethAddress, address wbtcAddress) =
+            config.activeNetworkConfig();
 
         tokenAddresses = [wethAddress, wbtcAddress];
         priceFeedAddresses = [ethUsdPriceFeed, btcUsdPriceFeed];
 
-        vm.startBroadcast(deployerKey);
+        vm.startBroadcast();
         DecentralizedStableCoin dsc = new DecentralizedStableCoin();
         DSCEngine dscEngine = new DSCEngine(tokenAddresses, priceFeedAddresses, address(dsc));
         dsc.transferOwnership(address(dscEngine));

--- a/script/HelperConfig.s.sol
+++ b/script/HelperConfig.s.sol
@@ -11,13 +11,11 @@ contract HelperConfig is Script {
         address btcUsdPriceFeed;
         address wethAddress;
         address wbtcAddress;
-        uint256 deployerKey;
     }
 
     uint8 public constant DECIMALS = 8;
     int256 public constant ETH_USD_PRICE = 2000e8; // $2000
     int256 public constant BTC_USD_PRICE = 1000e8; // $1000
-    uint256 public constant DEFAULT_ANVIL_KEY = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
 
     NetworkConfig public activeNetworkConfig;
 
@@ -31,13 +29,12 @@ contract HelperConfig is Script {
         }
     }
 
-    function getSepoliaEthConfig() public view returns (NetworkConfig memory) {
+    function getSepoliaEthConfig() public pure returns (NetworkConfig memory) {
         return NetworkConfig({
             ethUsdPriceFeed: 0x694AA1769357215DE4FAC081bf1f309aDC325306, // Sepolia WETH/USD Price Feed
             btcUsdPriceFeed: 0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43, // Sepolia WBTC/USD Price Feed
             wethAddress: 0xdd13E55209Fd76AfE204dBda4007C227904f0a81, // Sepolia WETH Address
-            wbtcAddress: 0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063, // Sepolia WBTC Address
-            deployerKey: vm.envUint("PRIVATE_KEY") // Deployer's private key
+            wbtcAddress: 0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063 // Sepolia WBTC Address
         });
     }
 
@@ -58,8 +55,7 @@ contract HelperConfig is Script {
             ethUsdPriceFeed: address(ethUsdPriceFeed),
             btcUsdPriceFeed: address(btcUsdPriceFeed),
             wethAddress: address(wethMock),
-            wbtcAddress: address(wbtcMock),
-            deployerKey: DEFAULT_ANVIL_KEY // Default Anvil key
+            wbtcAddress: address(wbtcMock)
         });
     }
 }

--- a/test/fuzz/Invariants.t.sol
+++ b/test/fuzz/Invariants.t.sol
@@ -30,7 +30,7 @@ contract Invariants is StdInvariant, Test {
         // Set up the invariants we want to test.
         deployer = new DeployDSCEngine();
         (dsc, dscEngine, config) = deployer.run();
-        (,, wethAddress, wbtcAddress,) = config.activeNetworkConfig();
+        (,, wethAddress, wbtcAddress) = config.activeNetworkConfig();
         // targetContract(address(dscEngine));
         handler = new Handler(dscEngine, dsc);
         targetContract(address(handler));

--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -74,7 +74,7 @@ contract DSCEngineTest is Test {
     function setUp() public {
         deployer = new DeployDSCEngine();
         (dsc, dscEngine, config) = deployer.run();
-        (ethUsdPriceFeed, btcUsdPriceFeed, wethAddress, wbtcAddress,) = config.activeNetworkConfig();
+        (ethUsdPriceFeed, btcUsdPriceFeed, wethAddress, wbtcAddress) = config.activeNetworkConfig();
         ERC20Mock(wethAddress).mint(USER, AMOUNT_COLLATERAL);
     }
 


### PR DESCRIPTION
Finalized keystore-based deployment without .env and also removing deployerKey variable